### PR TITLE
Update import from futures package

### DIFF
--- a/email_self_check.py
+++ b/email_self_check.py
@@ -1,6 +1,5 @@
-
 import requests
-import futures
+from concurrent.futures import *
 from bs4 import BeautifulSoup
 
 url = 'http://gu-email-renderer.appspot.com'
@@ -17,7 +16,7 @@ urls = {url + a['href'] for a in front_page_soup.find_all('a') if a['href'].star
 
 failed_urls = []
 
-with futures.ThreadPoolExecutor(max_workers=3) as executor:
+with ThreadPoolExecutor(max_workers=3) as executor:
 	url_reads = [executor.submit(lambda url: requests.get(url), url) for url in urls]
 
 	for read in url_reads:

--- a/email_self_check.py
+++ b/email_self_check.py
@@ -1,5 +1,5 @@
 import requests
-from concurrent.futures import *
+import concurrent.futures as futures
 from bs4 import BeautifulSoup
 
 url = 'http://gu-email-renderer.appspot.com'
@@ -16,7 +16,7 @@ urls = {url + a['href'] for a in front_page_soup.find_all('a') if a['href'].star
 
 failed_urls = []
 
-with ThreadPoolExecutor(max_workers=3) as executor:
+with futures.ThreadPoolExecutor(max_workers=3) as executor:
 	url_reads = [executor.submit(lambda url: requests.get(url), url) for url in urls]
 
 	for read in url_reads:

--- a/future_checkers.py
+++ b/future_checkers.py
@@ -1,6 +1,6 @@
 
 import requests
-import futures
+from concurrent.futures import *
 
 urls = [
 	'http://gu-email-renderer.appspot.com/daily-email-us/v6',
@@ -14,7 +14,7 @@ urls = [
 
 failed_urls = []
 
-with futures.ThreadPoolExecutor(max_workers=3) as executor:
+with ThreadPoolExecutor(max_workers=3) as executor:
 	url_reads = [executor.submit(lambda url: requests.get(url), url) for url in urls]
 
 	for read in url_reads:

--- a/future_checkers.py
+++ b/future_checkers.py
@@ -1,6 +1,5 @@
-
 import requests
-from concurrent.futures import *
+import concurrent.futures as futures
 
 urls = [
 	'http://gu-email-renderer.appspot.com/daily-email-us/v6',
@@ -14,7 +13,7 @@ urls = [
 
 failed_urls = []
 
-with ThreadPoolExecutor(max_workers=3) as executor:
+with futures.ThreadPoolExecutor(max_workers=3) as executor:
 	url_reads = [executor.submit(lambda url: requests.get(url), url) for url in urls]
 
 	for read in url_reads:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
-futures
+futures>=2.1
 beautifulsoup4


### PR DESCRIPTION
The current version gave me `ImportError: No module named futures`. This was down to the `futures` package exporting concurrent.futures rather than just futures, which was changed a while back for compatibility with python3.

https://github.com/agronholm/pythonfutures/blob/master/CHANGES#L81
